### PR TITLE
Acl editor implementation

### DIFF
--- a/bimrocket-server/src/main/java/org/bimrocket/service/file/Privilege.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/service/file/Privilege.java
@@ -37,5 +37,7 @@ package org.bimrocket.service.file;
 public enum Privilege
 {
   READ,
-  WRITE;
+  WRITE,
+  READ_ACL,
+  WRITE_ACL
 }

--- a/bimrocket-server/src/main/java/org/bimrocket/service/task/impl/graalvm/Host.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/service/task/impl/graalvm/Host.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import org.bimrocket.api.task.TaskData;
+import org.bimrocket.service.bcf.BcfService;
 import org.bimrocket.service.file.FileService;
 import org.bimrocket.service.ifcdb.IfcDatabaseService;
 import org.bimrocket.service.mail.MailService;
@@ -98,6 +99,11 @@ public class Host
   public IfcDatabaseService getIfcDatabaseService()
   {
     return CDI.current().select(IfcDatabaseService.class).get();
+  }
+
+  public BcfService getBcfService()
+  {
+    return CDI.current().select(BcfService.class).get();
   }
 
   public static Object toJava(Value value)

--- a/bimrocket-server/src/main/java/org/bimrocket/servlet/proxy/ProxyServlet.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/servlet/proxy/ProxyServlet.java
@@ -28,7 +28,7 @@
  * and
  * https://www.gnu.org/licenses/lgpl.txt
  */
-package org.bimrocket.servlet;
+package org.bimrocket.servlet.proxy;
 
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;

--- a/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/ACLXMLDeserializer.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/ACLXMLDeserializer.java
@@ -1,0 +1,97 @@
+package org.bimrocket.servlet.webdav;
+
+import org.bimrocket.service.file.ACL;
+import org.bimrocket.service.file.Privilege;
+import org.w3c.dom.*;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ACLXMLDeserializer
+{
+
+  public static String deserialize(ACL acl) throws Exception
+  {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    Document doc = db.newDocument();
+
+    Element root = doc.createElementNS("DAV:", "D:acl");
+    doc.appendChild(root);
+
+    // Map rol → privileges
+    Map<String, Set<Privilege>> roleToPrivileges = new HashMap<>();
+
+    for (Privilege priv : acl.getPrivileges())
+    {
+      Set<String> roleIds = acl.getRoleIdsForPrivilege(priv);
+      if (roleIds == null) continue;
+      for (String role : roleIds)
+      {
+        roleToPrivileges.computeIfAbsent(role, k -> new LinkedHashSet<>()).add(priv);
+      }
+    }
+
+    // Generate ACE by role
+    for (Map.Entry<String, Set<Privilege>> entry : roleToPrivileges.entrySet())
+    {
+      String roleId = entry.getKey();
+      Set<Privilege> privileges = entry.getValue();
+      if (privileges == null || privileges.isEmpty()) continue;
+
+      Element ace = doc.createElementNS("DAV:", "D:ace");
+      Element principal = doc.createElementNS("DAV:", "D:principal");
+
+      switch (roleId.toUpperCase()) {
+        case "EVERYONE":
+          principal.appendChild(doc.createElementNS("DAV:", "D:all"));
+          break;
+        case "AUTHENTICATED":
+          principal.appendChild(doc.createElementNS("DAV:", "D:authenticated"));
+          break;
+        default:
+          Element href = doc.createElementNS("DAV:", "D:href");
+          href.setTextContent(roleId);
+          principal.appendChild(href);
+          break;
+      }
+
+      ace.appendChild(principal);
+
+      Element grant = doc.createElementNS("DAV:", "D:grant");
+      for (Privilege priv : privileges)
+      {
+        Element privilege = doc.createElementNS("DAV:", "D:privilege");
+        Element privElement = doc.createElementNS("DAV:", "D:" + mapPrivilegeToXmlTag(priv));
+        privilege.appendChild(privElement);
+        grant.appendChild(privilege);
+      }
+
+      ace.appendChild(grant);
+      root.appendChild(ace);
+    }
+
+    // Output XML
+    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+    transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+
+    StringWriter writer = new StringWriter();
+    transformer.transform(new DOMSource(doc), new StreamResult(writer));
+    return writer.toString();
+  }
+
+  private static String mapPrivilegeToXmlTag(Privilege priv)
+  {
+    return priv.name().toLowerCase().replace('_', '-');
+  }
+}

--- a/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/ACLXMLSerializer.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/ACLXMLSerializer.java
@@ -1,0 +1,153 @@
+package org.bimrocket.servlet.webdav;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.bimrocket.service.file.ACL;
+import org.bimrocket.service.file.Privilege;
+import org.bimrocket.service.file.util.MutableACL;
+import org.bimrocket.service.security.SecurityConstants;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Deserialize XML to MutableACL object
+public class ACLXMLSerializer
+{
+
+  // Map of privileges
+  private static final Map<String, Privilege> PRIVILEGE_MAP = Map.of(
+        "READ", Privilege.READ,
+        "WRITE", Privilege.WRITE,
+        "READ_ACL", Privilege.READ_ACL,
+        "WRITE_ACL", Privilege.WRITE_ACL
+  );
+  private static final String BAD_ROLE = "Unknown Role ";
+
+  // Receives current user to replace when tag is D:owner
+  public static ACL serialize(String xml, String userId) throws Exception
+  {
+    MutableACL acl = new MutableACL();
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    // Map to group permissions
+    Map<String, List<String>> aclMap = new HashMap<>();
+    aclMap.put("READ_ACL", new ArrayList<>());
+    aclMap.put("WRITE_ACL", new ArrayList<>());
+    aclMap.put("READ", new ArrayList<>());
+    aclMap.put("WRITE", new ArrayList<>());
+
+    NodeList aceList = doc.getElementsByTagName("D:ace");
+
+    for (int i = 0; i < aceList.getLength(); i++)
+    {
+      Element ace = (Element) aceList.item(i);
+      String principal = getPrincipal(ace, userId);
+      NodeList privileges = ace.getElementsByTagName("D:privilege");
+
+      for (int j = 0; j < privileges.getLength(); j++)
+      {
+        Element privilege = (Element) privileges.item(j);
+
+        Element privilegeElement = getFirstElementChild(privilege);
+        if (privilegeElement == null) continue;
+        String privilegeType = privilegeElement.getNodeName();
+
+        switch (privilegeType)
+        {
+          case "D:read-acl":
+            aclMap.get("READ_ACL").add(principal);
+            break;
+          case "D:write-acl":
+            aclMap.get("WRITE_ACL").add(principal);
+            break;
+          case "D:read":
+            aclMap.get("READ").add(principal);
+            break;
+          case "D:write":
+            aclMap.get("WRITE").add(principal);
+            break;
+          default:
+            ObjectMapper mapper = new ObjectMapper();
+
+            Map<String, Object> info = new LinkedHashMap<>();
+            info.put("validPriveleges", Arrays.asList("read", "write", "read-acl", "write-acl"));
+
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("unknownPrivilege", privilegeType);
+            message.put("info", info);
+
+            Map<String, Object> root = new LinkedHashMap<>();
+            root.put("message", message);
+
+            String jsonError = mapper.writeValueAsString(root);
+            throw new IllegalArgumentException(jsonError);
+        }
+      }
+    }
+
+    // Retrieve results over acl object
+    aclMap.forEach((key, value) ->
+    {
+      Privilege priv = PRIVILEGE_MAP.getOrDefault(key, null);
+      acl.grant(value, priv);
+    });
+
+    return acl;
+  }
+
+  //Get First Element for Privileges
+  private static Element getFirstElementChild(Node node)
+  {
+    NodeList children = node.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++)
+    {
+      Node child = children.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE)
+      {
+        return (Element) child;
+      }
+    }
+    return null;
+  }
+
+  // Check role type
+  private static String getPrincipal(Element ace, String userId) throws Exception
+  {
+    NodeList principalNodes = ace.getElementsByTagName("D:principal");
+    if (principalNodes.getLength() > 0)
+    {
+      Element principalElement = (Element) principalNodes.item(0);
+
+      if (principalElement.getElementsByTagName("D:all").getLength() > 0)
+      {
+        return SecurityConstants.EVERYONE_ROLE;
+      }
+      else if (principalElement.getElementsByTagName("D:authenticated").getLength() > 0)
+      {
+        return SecurityConstants.AUTHENTICATED_ROLE;
+      }
+      else if (principalElement.getElementsByTagName("D:href").getLength() > 0)
+      {
+        return principalElement.getElementsByTagName("D:href").item(0).getTextContent();
+      }
+    }
+    return "UNKNOWN";
+  }
+}

--- a/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/WebdavServlet.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/servlet/webdav/WebdavServlet.java
@@ -28,7 +28,7 @@
  * and
  * https://www.gnu.org/licenses/lgpl.txt
  */
-package org.bimrocket.servlet;
+package org.bimrocket.servlet.webdav;
 
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;
@@ -36,31 +36,36 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
+import org.apache.commons.io.IOUtils;
+import org.bimrocket.api.security.User;
+import org.bimrocket.exception.AccessDeniedException;
+import org.bimrocket.exception.InvalidRequestException;
+import org.bimrocket.exception.NotAuthorizedException;
+import org.bimrocket.exception.NotFoundException;
+import org.bimrocket.service.file.*;
+import org.bimrocket.service.file.exception.LockedFileException;
+import org.bimrocket.service.file.util.MutableACL;
+import org.bimrocket.service.security.SecurityService;
+import org.bimrocket.util.URIEncoder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.IOUtils;
-import org.bimrocket.exception.AccessDeniedException;
-import org.bimrocket.exception.InvalidRequestException;
-import org.bimrocket.exception.NotAuthorizedException;
-import org.bimrocket.exception.NotFoundException;
-import org.bimrocket.service.file.FileService;
-import org.bimrocket.service.file.FindOptions;
-import org.bimrocket.service.file.Metadata;
-import org.bimrocket.service.file.Path;
-import org.bimrocket.service.file.exception.LockedFileException;
-import org.bimrocket.util.URIEncoder;
+
 
 /**
  *
@@ -82,6 +87,9 @@ public class WebdavServlet extends HttpServlet
 
   @Inject
   transient FileService fileService;
+
+  @Inject
+  transient SecurityService securityService;
 
   @Override
   protected void doOptions(HttpServletRequest request, HttpServletResponse response)
@@ -105,14 +113,29 @@ public class WebdavServlet extends HttpServlet
   }
 
   protected void doPropfind(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
+    throws ServletException, IOException, Exception
   {
     Path path = getPath(request);
 
     logParameters(request, path);
 
-//    String body = IOUtils.toString(request.getReader());
-//    System.out.println("\n\nPROPFIND " + path + "\n" + body);
+    List<String> requestedProperties = parsePropfindBody(request);
+    boolean aclRequested = requestedProperties.contains("{DAV:}acl");
+    if (aclRequested)
+    {
+      ACL acl = fileService.getACL(path);
+      String xml = ACLXMLDeserializer.deserialize(acl);
+
+      response.setContentType("application/xml");
+      response.setCharacterEncoding("UTF-8");
+      response.setStatus(207);
+
+      try (Writer writer = response.getWriter())
+      {
+        writer.write(xml);
+      }
+      return;
+    }
 
     FindOptions options = new FindOptions();
 
@@ -134,6 +157,9 @@ public class WebdavServlet extends HttpServlet
     if (metadatas.isEmpty())
     {
       response.setStatus(404);
+      response.setContentType("text/plain");
+      response.getWriter().println("The requested resource was not found on this server.");
+
     }
     else
     {
@@ -177,7 +203,14 @@ public class WebdavServlet extends HttpServlet
     Metadata metadata = fileService.get(path);
     if (metadata.isCollection())
     {
-      doPropfind(request, response);
+        try
+        {
+          doPropfind(request, response);
+        }
+        catch (Exception e)
+        {
+          throw new RuntimeException(e);
+        }
     }
     else
     {
@@ -216,8 +249,39 @@ public class WebdavServlet extends HttpServlet
   }
 
   protected void doAcl(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
+    throws ServletException, IOException, Exception
   {
+    ACL acl = null;
+
+    String requestBody = IOUtils.toString(request.getReader());
+
+    Path path = getPath(request);
+    logParameters(request, path);
+
+    User user = securityService.getCurrentUser();
+
+    try
+    {
+      acl = ACLXMLSerializer.serialize(requestBody, user.getId());
+    }
+    catch( IllegalArgumentException e)
+    {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.setContentType("application/json");
+      response.getWriter().write(e.getMessage());
+      return;
+    }
+    catch (Exception e)
+    {
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.setContentType("text/plain");
+      response.getWriter().write("Internal Server Error");
+      return;
+    }
+
+    fileService.setACL(path, acl);
+
+    response.setStatus(HttpServletResponse.SC_OK);
   }
 
   protected void doLock(HttpServletRequest request, HttpServletResponse response)
@@ -456,4 +520,44 @@ public class WebdavServlet extends HttpServlet
       response.setHeader("WWW-Authenticate", "Basic realm=\"bimrocket realm\"");
     }
   }
+
+  private List<String> parsePropfindBody(HttpServletRequest request) throws IOException
+  {
+    List<String> properties = new ArrayList<>();
+    byte[] requestBody = request.getInputStream().readAllBytes();
+    if (requestBody.length == 0) {
+      return properties;
+    }
+
+    try (ByteArrayInputStream inputStream = new ByteArrayInputStream(requestBody))
+    {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      Document doc = builder.parse(inputStream);
+
+      NodeList propElements = doc.getElementsByTagNameNS("DAV:", "prop");
+      if (propElements.getLength() == 0)
+      {
+        return properties;
+      }
+
+      NodeList propNodes = propElements.item(0).getChildNodes();
+
+      for (int i = 0; i < propNodes.getLength(); i++)
+      {
+        Node node = propNodes.item(i);
+        if (node.getNodeType() == Node.ELEMENT_NODE)
+        {
+          properties.add("{" + node.getNamespaceURI() + "}" + node.getLocalName());
+        }
+      }
+    }
+    catch (Exception e)
+    {
+      throw new IOException("Failed to parse PROPFIND body", e);
+    }
+    return properties;
+  }
+
 }

--- a/bimrocket-webapp/src/main/webapp/css/tools.css
+++ b/bimrocket-webapp/src/main/webapp/css/tools.css
@@ -852,6 +852,25 @@ div.field_flex > select
   flex-grow: 1;
 }
 
+.dialog .body div.acl_directory > input[type=text]
+{
+  display: inline-block;
+  width: 80%;
+  flex-grow: 1;
+  font-size:13px;
+  font-weight:normal;
+  text-align: left;
+  line-height: 20px;
+  padding:1px;
+  padding-left: 2px;
+  color: #804040;
+  border: 1px solid #c0c0c0;
+  overflow: hidden;
+  margin-left: 8px;
+  cursor: not-allowed; 
+  pointer-events: none;
+}
+
 .dialog .footer button
 {
   min-width: 40px;

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -579,7 +579,8 @@ export const translations =
   "title.acl_editor" : "ACL Permissions Editor",
   "title.acl_editor_success": "Permissions saved",
   "title.acl_editor_error": "Error saving",
-
+  "title.acl_not_found": "ACL not found",
+  "title.confirm_save": "Confirmation",
 
   "message.measure_length" : (length, units) => `Length: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Area: ${area} ${units}2`,
@@ -639,6 +640,9 @@ export const translations =
   "message.edit_acl_success": "Permissions were updated successfully.",
   "message.edit_acl_denied": result => `Permissions could not be saved: \n${result}`,
   "message.edit_acl_error": "An error occurred while processing the permissions. Please try again.",
+  "message.invalid_privilege_detail": ({ privilege, options }) => `The value "${privilege}" is not valid. Valid values are: ${options}.`,
+  "message.acl_not_found_create_new": "ACL not found. Do you want to create a new one?",
+
 
   "question.discard_changes" : name => `Discard unsaved changes in ${name || 'editor'}?`,
   "question.delete_service" : name => `Do you want to delete the ${name} service?`,
@@ -649,6 +653,7 @@ export const translations =
   "question.remove_featured_properties" : "Remove all featured properties?",
   "question.create_new_scene" : "Do you want to create a new scene?",
   "question.delete_conversation" : "Do you want to delete the conversation?",
+  "question.confirm_save_changes": "Do you want to confirm the changes?",
 
   "controller.AutoPilotController" : "Drives an object.",
   "controller.Brain4itPostController" : "Posts a value to Brain4it.",

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -639,7 +639,6 @@ export const translations =
   "message.selected_surfaces" : count => `Selected surfaces: ${count}`,
 
   "message.edit_acl_success": "Permissions were updated successfully.",
-  "message.edit_acl_denied": result => `Permissions could not be saved: \n${result}`,
   "message.invalid_privileges": "Errors found in the input privileges.",
   "message.edit_acl_json_error": "JSON parsing error. Please validate your syntax.",
 

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -50,6 +50,7 @@ export const translations =
   "button.update" : "Update",
   "button.reset" : "Reset",
   "button.link" : "Link",
+  "button.edit_acl": "Edit ACL",
 
   "button.preview_material" : "Preview material",
   "button.apply_material" : "Apply material",
@@ -529,6 +530,8 @@ export const translations =
   "label.inspector_links_tab" : "Links",
   "label.inspector_featured_tab" : "Featured properties",
 
+  "label.acl_permissions": "Definition of permissions (JSON format)",
+
   "option.no_groups" : "Without groups",
   "option.value_asc" : "Value (ascending)",
   "option.value_desc" : "Value (descending)",
@@ -573,6 +576,10 @@ export const translations =
   "title.rename_material" : "Rename material",
   "title.delete_conversation" : "Delete conversation",
   "title.chatgpt_setup" : "ChatGPT setup",
+  "title.acl_editor" : "ACL Permissions Editor",
+  "title.acl_editor_success": "Permissions saved",
+  "title.acl_editor_error": "Error saving",
+
 
   "message.measure_length" : (length, units) => `Length: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Area: ${area} ${units}2`,
@@ -628,6 +635,10 @@ export const translations =
   "message.link_created" : "Link created.",
 
   "message.selected_surfaces" : count => `Selected surfaces: ${count}`,
+
+  "message.edit_acl_success": "Permissions were updated successfully.",
+  "message.edit_acl_denied": result => `Permissions could not be saved: \n${result}`,
+  "message.edit_acl_error": "An error occurred while processing the permissions. Please try again.",
 
   "question.discard_changes" : name => `Discard unsaved changes in ${name || 'editor'}?`,
   "question.delete_service" : name => `Do you want to delete the ${name} service?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -640,9 +640,7 @@ export const translations =
 
   "message.edit_acl_success": "Permissions were updated successfully.",
   "message.edit_acl_denied": result => `Permissions could not be saved: \n${result}`,
-  "message.edit_acl_error": "An error occurred while processing the permissions. Please try again.",
   "message.invalid_privileges": "Errors found in the input privileges.",
-  "message.acl_not_found_create_new": "ACL not found. Do you want to create a new one?",
   "message.edit_acl_json_error": "JSON parsing error. Please validate your syntax.",
 
   "question.discard_changes" : name => `Discard unsaved changes in ${name || 'editor'}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -530,6 +530,7 @@ export const translations =
   "label.inspector_links_tab" : "Links",
   "label.inspector_featured_tab" : "Featured properties",
 
+  "label.acl_path_editing": "ACL path editing:",
   "label.acl_permissions": "Definition of permissions (JSON format)",
 
   "option.no_groups" : "Without groups",
@@ -640,9 +641,9 @@ export const translations =
   "message.edit_acl_success": "Permissions were updated successfully.",
   "message.edit_acl_denied": result => `Permissions could not be saved: \n${result}`,
   "message.edit_acl_error": "An error occurred while processing the permissions. Please try again.",
-  "message.invalid_privilege_detail": ({ privilege, options }) => `The value "${privilege}" is not valid. Valid values are: ${options}.`,
+  "message.invalid_privileges": "Errors found in the input privileges.",
   "message.acl_not_found_create_new": "ACL not found. Do you want to create a new one?",
-
+  "message.edit_acl_json_error": "JSON parsing error. Please validate your syntax.",
 
   "question.discard_changes" : name => `Discard unsaved changes in ${name || 'editor'}?`,
   "question.delete_service" : name => `Do you want to delete the ${name} service?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -640,9 +640,7 @@ export const translations =
 
   "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
   "message.edit_acl_denied": result => `No s'han pogut desar els permisos: \n${result}`,
-  "message.edit_acl_error": "S'ha produït un error en processar els permisos. Torna-ho a intentar.",
   "message.invalid_privileges": "Hi ha errors en els privilegis introduïts.",
-  "message.acl_not_found_create_new": "No s'ha trobat l'ACL per a aquest directori. Vols crear-ne un de nou?",
   "message.edit_acl_json_error": "Error en processar el JSON. Comprova que la sintaxi és correcta.",
 
   "question.discard_changes" : name => `Vols descartar els canvis no desats en ${name || " l'editor"}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -579,6 +579,8 @@ export const translations =
   "title.acl_editor" : "Editor de permisos ACL",
   "title.acl_editor_success": "Permisos desats",
   "title.acl_editor_error": "Error en desar",
+  "title.acl_not_found": "No s'ha trobat l'ACL",
+  "title.confirm_save": "Confirmació",
 
   "message.measure_length" : (length, units) => `Longitud: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Àrea: ${area} ${units}2`,
@@ -638,6 +640,8 @@ export const translations =
   "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
   "message.edit_acl_denied": result => `No s'han pogut desar els permisos: \n${result}`,
   "message.edit_acl_error": "S'ha produït un error en processar els permisos. Torna-ho a intentar.",
+  "message.invalid_privilege_detail": ({ privilege, options }) => `El valor "${privilege}" no es vàlid. Els valors vàlids són: ${options}.`,
+  "message.acl_not_found_create_new": "No s'ha trobat l'ACL per a aquest directori. Vols crear-ne un de nou?",
 
   "question.discard_changes" : name => `Vols descartar els canvis no desats en ${name || " l'editor"}?`,
   "question.delete_service" : name => `Vols esborrar el servei ${name}?`,
@@ -648,6 +652,7 @@ export const translations =
   "question.remove_featured_properties" : "Vols esborrar totes les propietats destacades?",
   "question.create_new_scene" : "Vols crear una nova escena?",
   "question.delete_conversation" : "Vols esborrar la conversa?",
+  "question.confirm_save_changes": "Vols confirmar els canvis?",
 
   "controller.AutoPilotController" : "Condueix un objecte.",
   "controller.Brain4itPostController" : "Fa un POST a Brain4it.",

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -530,6 +530,7 @@ export const translations =
   "label.inspector_links_tab" : "Enllaços",
   "label.inspector_featured_tab" : "Propietats destacades",
 
+  "label.acl_path_editing": "Editant ruta ACL:",
   "label.acl_permissions": "Definició de permisos (format JSON)",
 
   "option.no_groups" : "Sense agrupacions",
@@ -640,8 +641,9 @@ export const translations =
   "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
   "message.edit_acl_denied": result => `No s'han pogut desar els permisos: \n${result}`,
   "message.edit_acl_error": "S'ha produït un error en processar els permisos. Torna-ho a intentar.",
-  "message.invalid_privilege_detail": ({ privilege, options }) => `El valor "${privilege}" no es vàlid. Els valors vàlids són: ${options}.`,
+  "message.invalid_privileges": "Hi ha errors en els privilegis introduïts.",
   "message.acl_not_found_create_new": "No s'ha trobat l'ACL per a aquest directori. Vols crear-ne un de nou?",
+  "message.edit_acl_json_error": "Error en processar el JSON. Comprova que la sintaxi és correcta.",
 
   "question.discard_changes" : name => `Vols descartar els canvis no desats en ${name || " l'editor"}?`,
   "question.delete_service" : name => `Vols esborrar el servei ${name}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -50,6 +50,7 @@ export const translations =
   "button.update" : "Actualitza",
   "button.reset" : "Restableix",
   "button.link" : "Enllaça",
+  "button.edit_acl": "Editar ACL",
 
   "button.preview_material" : "Prova material",
   "button.apply_material" : "Aplica material",
@@ -529,6 +530,8 @@ export const translations =
   "label.inspector_links_tab" : "Enllaços",
   "label.inspector_featured_tab" : "Propietats destacades",
 
+  "label.acl_permissions": "Definició de permisos (format JSON)",
+
   "option.no_groups" : "Sense agrupacions",
   "option.value_asc" : "Valor (ascendent)",
   "option.value_desc" : "Valor (descendent)",
@@ -573,6 +576,9 @@ export const translations =
   "title.rename_material" : "Reanomena material",
   "title.delete_conversation" : "Esborra conversa",
   "title.chatgpt_setup" : "Configuració de ChatGPT",
+  "title.acl_editor" : "Editor de permisos ACL",
+  "title.acl_editor_success": "Permisos desats",
+  "title.acl_editor_error": "Error en desar",
 
   "message.measure_length" : (length, units) => `Longitud: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Àrea: ${area} ${units}2`,
@@ -628,6 +634,10 @@ export const translations =
   "message.link_created" : "Enllaç creat.",
 
   "message.selected_surfaces" : count => `Superfícies seleccionades: ${count}`,
+
+  "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
+  "message.edit_acl_denied": result => `No s'han pogut desar els permisos: \n${result}`,
+  "message.edit_acl_error": "S'ha produït un error en processar els permisos. Torna-ho a intentar.",
 
   "question.discard_changes" : name => `Vols descartar els canvis no desats en ${name || " l'editor"}?`,
   "question.delete_service" : name => `Vols esborrar el servei ${name}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -639,7 +639,6 @@ export const translations =
   "message.selected_surfaces" : count => `Superfícies seleccionades: ${count}`,
 
   "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
-  "message.edit_acl_denied": result => `No s'han pogut desar els permisos: \n${result}`,
   "message.invalid_privileges": "Hi ha errors en els privilegis introduïts.",
   "message.edit_acl_json_error": "Error en processar el JSON. Comprova que la sintaxi és correcta.",
 

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -639,10 +639,9 @@ export const translations =
   "message.selected_surfaces" : count => `Superficies seleccionadas: ${count}`,
 
   "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
-  "message.edit_acl_denied" : result => `No se pudieron guardar los permisos: \n${result}`,
   "message.invalid_privileges": "Hay errores en los privilegios introducidos.",
   "message.edit_acl_json_error": "Error al procesar el JSON. Comprueba que la sintaxis es correcta.",
-
+  
   "question.discard_changes" : name => `Descartar los cambios no guardados en ${name || 'el editor'}?`,
   "question.delete_service" : name => `Quieres borrar el servicio ${name}?`,
   "question.delete_folder" : name => `Quieres borrar la carpeta ${name}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -579,6 +579,8 @@ export const translations =
   "title.acl_editor" : "Editor de permisos ACL",
   "title.acl_editor_success" : "Permisos guardados",
   "title.acl_editor_error" : "Error al guardar",
+  "title.acl_not_found": "No se ha encontrado el ACL",
+  "title.confirm_save": "Confirmación",
 
   "message.measure_length" : (length, units) => `Longitud: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Área: ${area} ${units}2`,
@@ -638,6 +640,8 @@ export const translations =
   "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
   "message.edit_acl_denied" : result => `No se pudieron guardar los permisos: \n${result}`,
   "message.edit_acl_error" : "Ocurrió un error al procesar los permisos. Intenta nuevamente.",
+  "message.invalid_privilege_detail": ({ privilege, options }) => `El valor "${privilege}" no es válido. Los valores válidos son: ${options}.`,
+  "message.acl_not_found_create_new": "No se ha encontrado el ACL. ¿Quieres crear uno nuevo?",
 
   "question.discard_changes" : name => `Descartar los cambios no guardados en ${name || 'el editor'}?`,
   "question.delete_service" : name => `Quieres borrar el servicio ${name}?`,
@@ -648,6 +652,7 @@ export const translations =
   "question.remove_featured_properties" : "Quieres borrar todas las propiedades destacadas?",
   "question.create_new_scene" : "Quieres crear una nueva escena?",
   "question.delete_conversation" : "Quieres borrar la conversación?",
+  "question.confirm_save_changes": "Quieres confirmar los cambios?",
 
   "controller.AutoPilotController" : "Conduce un objeto.",
   "controller.Brain4itPostController" : "Hace un POST a Brain4it.",

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -50,6 +50,7 @@ export const translations =
   "button.update" : "Actualizar",
   "button.reset" : "Restablecer",
   "button.link" : "Enlazar",
+  "button.edit_acl": "Editar ACL",
 
   "button.preview_material" : "Probar material",
   "button.apply_material" : "Aplicar material",
@@ -529,6 +530,8 @@ export const translations =
   "label.inspector_links_tab" : "Enlaces",
   "label.inspector_featured_tab" : "Propiedades destacadas",
 
+  "label.acl_permissions": "Definición de permisos (formato JSON)",
+
   "option.no_groups" : "Sin agrupaciones",
   "option.value_asc" : "Valor (ascendente)",
   "option.value_desc" : "Valor (descendente)",
@@ -573,6 +576,9 @@ export const translations =
   "title.rename_material" : "Renombrar material",
   "title.delete_conversation" : "Borrar conversación",
   "title.chatgpt_setup" : "Configuración de ChatGPT",
+  "title.acl_editor" : "Editor de permisos ACL",
+  "title.acl_editor_success" : "Permisos guardados",
+  "title.acl_editor_error" : "Error al guardar",
 
   "message.measure_length" : (length, units) => `Longitud: ${length} ${units}`,
   "message.measure_area" : (area, units) => `Área: ${area} ${units}2`,
@@ -628,6 +634,10 @@ export const translations =
   "message.link_created" : "Enlace creado.",
 
   "message.selected_surfaces" : count => `Superficies seleccionadas: ${count}`,
+
+  "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
+  "message.edit_acl_denied" : result => `No se pudieron guardar los permisos: \n${result}`,
+  "message.edit_acl_error" : "Ocurrió un error al procesar los permisos. Intenta nuevamente.",
 
   "question.discard_changes" : name => `Descartar los cambios no guardados en ${name || 'el editor'}?`,
   "question.delete_service" : name => `Quieres borrar el servicio ${name}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -640,9 +640,7 @@ export const translations =
 
   "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
   "message.edit_acl_denied" : result => `No se pudieron guardar los permisos: \n${result}`,
-  "message.edit_acl_error" : "Ocurrió un error al procesar los permisos. Intenta nuevamente.",
   "message.invalid_privileges": "Hay errores en los privilegios introducidos.",
-  "message.acl_not_found_create_new": "No se ha encontrado el ACL. ¿Quieres crear uno nuevo?",
   "message.edit_acl_json_error": "Error al procesar el JSON. Comprueba que la sintaxis es correcta.",
 
   "question.discard_changes" : name => `Descartar los cambios no guardados en ${name || 'el editor'}?`,

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -530,6 +530,7 @@ export const translations =
   "label.inspector_links_tab" : "Enlaces",
   "label.inspector_featured_tab" : "Propiedades destacadas",
 
+  "label.acl_path_editing": "Editando ruta ACL:",
   "label.acl_permissions": "Definición de permisos (formato JSON)",
 
   "option.no_groups" : "Sin agrupaciones",
@@ -640,8 +641,9 @@ export const translations =
   "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
   "message.edit_acl_denied" : result => `No se pudieron guardar los permisos: \n${result}`,
   "message.edit_acl_error" : "Ocurrió un error al procesar los permisos. Intenta nuevamente.",
-  "message.invalid_privilege_detail": ({ privilege, options }) => `El valor "${privilege}" no es válido. Los valores válidos son: ${options}.`,
+  "message.invalid_privileges": "Hay errores en los privilegios introducidos.",
   "message.acl_not_found_create_new": "No se ha encontrado el ACL. ¿Quieres crear uno nuevo?",
+  "message.edit_acl_json_error": "Error al procesar el JSON. Comprueba que la sintaxis es correcta.",
 
   "question.discard_changes" : name => `Descartar los cambios no guardados en ${name || 'el editor'}?`,
   "question.delete_service" : name => `Quieres borrar el servicio ${name}?`,

--- a/bimrocket-webapp/src/main/webapp/js/io/FileService.js
+++ b/bimrocket-webapp/src/main/webapp/js/io/FileService.js
@@ -50,6 +50,7 @@ class Result
   static ERROR = 1; // unknown error
   static INVALID_CREDENTIALS = 2;
   static FORBIDDEN = 3;
+  static BAD_REQUEST = 4;
 
   constructor(status, message, path, metadata, entries, data)
   {

--- a/bimrocket-webapp/src/main/webapp/js/io/FileService.js
+++ b/bimrocket-webapp/src/main/webapp/js/io/FileService.js
@@ -32,6 +32,16 @@ class FileService extends Service
   {
     readyCallback(new Result(Result.ERROR, "Not implemented."));
   }
+
+  setACL(path, acl, readyCallback)
+  {
+    readyCallback(new Result(Result.ERROR, "Not implemented.")); // by default, not implemented
+  }
+
+  getACL(path, readyCallback)
+  {
+    readyCallback(new Result(Result.ERROR, "Not implemented."));
+  }
 }
 
 class Result
@@ -67,4 +77,22 @@ class Metadata
   }
 }
 
-export {FileService, Result, Metadata };
+class ACL
+{
+  constructor()
+  {
+    this.roles = {};
+  }
+  grant(roleId, privilege)
+  {
+    let roles = this.roles[roleId];
+    if (!roles)
+    {
+      roles = [];
+      this.roles[roleId] = roles;
+    }
+    if (!roles.includes(privilege)) roles.push(privilege);
+ }
+}
+
+export {FileService, Result, Metadata, ACL };

--- a/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
+++ b/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
@@ -363,14 +363,17 @@ class WebdavService extends FileService
       const hrefElement = aceElement.getElementsByTagNameNS("DAV:", "href")[0];
       const allElement = aceElement.getElementsByTagNameNS("DAV:", "all")[0];
 
-      if (hrefElement) {
+      if (hrefElement) 
+      {
         role = hrefElement.textContent.trim();
-      } else if (allElement) {
+      } 
+      else if (allElement) 
+      {
         role = "EVERYONE";
       }
       if (!role) continue;
 
-      const privileges = [];
+      let privileges = [];
       const privilegeElements = aceElement.getElementsByTagNameNS("DAV:", "privilege");
 
       for (let j = 0; j < privilegeElements.length; j++) 
@@ -385,7 +388,8 @@ class WebdavService extends FileService
         }
       }
 
-      if (privileges.length > 0) {
+      if (privileges.length > 0) 
+      {
         acl[role] = privileges;
       }
     }

--- a/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
+++ b/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
@@ -322,6 +322,7 @@ class WebdavService extends FileService
     let resultStatus;
     switch (status)
     {
+      case 400: resultStatus = Result.BAD_REQUEST; break;
       case 401: resultStatus = Result.INVALID_CREDENTIALS; break;
       case 403: resultStatus = Result.FORBIDDEN; break;
       default: resultStatus = Result.ERROR;

--- a/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
+++ b/bimrocket-webapp/src/main/webapp/js/io/WebdavService.js
@@ -479,7 +479,7 @@ class WebdavService extends FileService
 
       request.onerror = () => readyCallback(new Result(ERROR, "Connection error"));
       request.onload = () => {
-        if (request.status === 200) 
+        if (request.status === 200 || request.status === 207) 
         {
           try 
           {

--- a/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
@@ -42,7 +42,6 @@ class ACLEditorDialog extends Dialog
       {
         const json = this.editorView.state.doc.toString();
         const data = JSON.parse(json);
-        
         this.fileService.setACL(this.aclFilePath, data, result => {
           if (result.status === Result.OK) 
           {
@@ -50,40 +49,24 @@ class ACLEditorDialog extends Dialog
               .setClassName("info")
               .setI18N(this.application.i18n).show();
             this.hide();
-          } else 
-          {
-          let dialog;
-          if (result.path === "message.invalid_acl_privileges") 
-          {
-            const details = result.metadata.entries.map(entry =>
-              this.application.i18n.get("message.invalid_privilege_detail", {
-                role: entry.role,
-                privilege: entry.invalidPrivilege,
-                options: entry.validOptions.join(', ')
-              })
-            ).join('\n');
-            console.log(details);
-            dialog = MessageDialog.create(
-              "title.acl_editor_error",
-              details
-            );
-          } 
+          }
+          else if (result.status === Result.BAD_REQUEST) 
+          { 
+            MessageDialog.create("title.acl_editor_error", "message.invalid_privileges")
+              .setClassName("error")
+              .setI18N(this.application.i18n).show();
+          }
           else 
           {
-            dialog = MessageDialog.create(
-              "title.acl_editor_error",
-              result.message
-            );
-          }
-          dialog.setClassName("error")
-            .setI18N(this.application.i18n)
-            .show();
-
+            MessageDialog.create("title.acl_editor_error", "message.edit_acl_denied", result.message)
+              .setClassName("error")
+              .setI18N(this.application.i18n).show();
           }
         });
-      } catch (error) 
+      } 
+      catch (error) 
       {
-        MessageDialog.create("Error", "message.edit_acl_error", error.message)
+        MessageDialog.create("title.acl_editor_error", "message.edit_acl_json_error", error.message)
           .setClassName("error")
           .setI18N(this.application.i18n).show();
       }
@@ -99,7 +82,6 @@ class ACLEditorDialog extends Dialog
     });
   }
 
-
   setACL(data)
   {
     const json = JSON.stringify(data, null, 2);
@@ -107,8 +89,8 @@ class ACLEditorDialog extends Dialog
       changes: { from: 0, to: this.editorView.state.doc.length, insert: json }
     });
   }
-
-  load()
+  
+  load() 
   {
     const loadACL = () => {
       this.fileService.getACL(this.aclFilePath, result => 
@@ -128,22 +110,15 @@ class ACLEditorDialog extends Dialog
         }
         else if (result.status === Result.ERROR) 
         {
-          ConfirmDialog.create("title.acl_not_found", "message.acl_not_found_create_new")
-            .setI18N(this.application.i18n)
-            .setAcceptLabel("button.yes")
-            .setCancelLabel("button.no")
-            .setAction(() => {
-              this.setACL({});
-              this.show();
-            })
-            .show();
+          MessageDialog.create("Error", result.message)
+            .setClassName("error")
+            .setI18N(this.application.i18n).show();
         }
         else 
         {
           MessageDialog.create("message.action_denied", result.message)
             .setClassName("error")
-            .setI18N(this.application.i18n)
-            .show();
+            .setI18N(this.application.i18n).show();
         }
       });
     };

--- a/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
@@ -1,19 +1,25 @@
 import { Dialog } from "./Dialog.js";
 import { Controls } from "./Controls.js";
 import { MessageDialog } from "./MessageDialog.js";
+import { ConfirmDialog } from "./ConfirmDialog.js";
+import { I18N } from "../i18n/I18N.js";
 import { Result } from "../io/FileService.js";
 
 class ACLEditorDialog extends Dialog
 {
-  constructor(application, fileService, aclFilePath)
+  constructor(application, fileService, aclFilePath, fileExplorer)
   {
     super("title.acl_editor");
     this.application = application;
     this.setI18N(application.i18n);
     this.fileService = fileService;
     this.aclFilePath = aclFilePath;
+    this.fileExplorer = fileExplorer;
 
-    this.setSize(600, 400);
+    this.setSize(600, 500);
+
+    this.nameField = this.addTextField("name", "label.acl_path_editing", aclFilePath === "/" ? "/Remote" : aclFilePath,
+      "acl_directory");
 
     this.editorView = Controls.addCodeEditor(
       this.bodyElem,
@@ -26,33 +32,70 @@ class ACLEditorDialog extends Dialog
     this.createSaveButton();
   }
 
-  createSaveButton() {
+  createSaveButton() 
+  {
     const buttonContainer = document.createElement("div");
-    buttonContainer.className = "acl-buttons-right";
     this.bodyElem.appendChild(buttonContainer);
 
-    this.addButton("saveAcl", "button.save", () => {
-      try {
+    const saveAction = () => {
+      try 
+      {
         const json = this.editorView.state.doc.toString();
         const data = JSON.parse(json);
         
         this.fileService.setACL(this.aclFilePath, data, result => {
-          if (result.status === Result.OK) {
+          if (result.status === Result.OK) 
+          {
             MessageDialog.create("title.acl_editor_success", "message.edit_acl_success")
               .setClassName("info")
               .setI18N(this.application.i18n).show();
             this.hide();
-          } else {
-            MessageDialog.create("title.acl_editor_error", "message.edit_acl_denied", result.message)
-              .setClassName("error")
-              .setI18N(this.application.i18n).show();
+          } else 
+          {
+          let dialog;
+          if (result.path === "message.invalid_acl_privileges") 
+          {
+            const details = result.metadata.entries.map(entry =>
+              this.application.i18n.get("message.invalid_privilege_detail", {
+                role: entry.role,
+                privilege: entry.invalidPrivilege,
+                options: entry.validOptions.join(', ')
+              })
+            ).join('\n');
+            console.log(details);
+            dialog = MessageDialog.create(
+              "title.acl_editor_error",
+              details
+            );
+          } 
+          else 
+          {
+            dialog = MessageDialog.create(
+              "title.acl_editor_error",
+              result.message
+            );
+          }
+          dialog.setClassName("error")
+            .setI18N(this.application.i18n)
+            .show();
+
           }
         });
-      } catch (error) {
+      } catch (error) 
+      {
         MessageDialog.create("Error", "message.edit_acl_error", error.message)
           .setClassName("error")
           .setI18N(this.application.i18n).show();
       }
+    };
+
+    this.addButton("saveACL", "button.save", () => {
+      ConfirmDialog.create("title.confirm_save", "question.confirm_save_changes")
+        .setI18N(this.application.i18n)
+        .setAcceptLabel("button.yes")
+        .setCancelLabel("button.no")
+        .setAction(saveAction)
+        .show();
     });
   }
 
@@ -67,10 +110,44 @@ class ACLEditorDialog extends Dialog
 
   load()
   {
-    this.fileService.getACL(this.aclFilePath, result =>
-    {
-      this.show();
-    });
+    const loadACL = () => {
+      this.fileService.getACL(this.aclFilePath, result => 
+      {
+        if (result.status === Result.OK) 
+        {
+          this.setACL(result.message);
+          this.show();
+        } 
+        else if (result.status === Result.INVALID_CREDENTIALS || result.status === Result.FORBIDDEN) 
+        {
+          this.fileExplorer.requestCredentials(
+            result.status === Result.INVALID_CREDENTIALS ? 
+              "message.invalid_credentials" : "message.action_denied",
+            () => loadACL()
+          );
+        }
+        else if (result.status === Result.ERROR) 
+        {
+          ConfirmDialog.create("title.acl_not_found", "message.acl_not_found_create_new")
+            .setI18N(this.application.i18n)
+            .setAcceptLabel("button.yes")
+            .setCancelLabel("button.no")
+            .setAction(() => {
+              this.setACL({});
+              this.show();
+            })
+            .show();
+        }
+        else 
+        {
+          MessageDialog.create("message.action_denied", result.message)
+            .setClassName("error")
+            .setI18N(this.application.i18n)
+            .show();
+        }
+      });
+    };
+    loadACL();
   }
 }
 

--- a/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/ACLEditorDialog.js
@@ -1,0 +1,77 @@
+import { Dialog } from "./Dialog.js";
+import { Controls } from "./Controls.js";
+import { MessageDialog } from "./MessageDialog.js";
+import { Result } from "../io/FileService.js";
+
+class ACLEditorDialog extends Dialog
+{
+  constructor(application, fileService, aclFilePath)
+  {
+    super("title.acl_editor");
+    this.application = application;
+    this.setI18N(application.i18n);
+    this.fileService = fileService;
+    this.aclFilePath = aclFilePath;
+
+    this.setSize(600, 400);
+
+    this.editorView = Controls.addCodeEditor(
+      this.bodyElem,
+      "acl_json",
+      "label.acl_permissions",
+      "",
+      { language: "json", height: "calc(100% - 8px)" }
+    );
+
+    this.createSaveButton();
+  }
+
+  createSaveButton() {
+    const buttonContainer = document.createElement("div");
+    buttonContainer.className = "acl-buttons-right";
+    this.bodyElem.appendChild(buttonContainer);
+
+    this.addButton("saveAcl", "button.save", () => {
+      try {
+        const json = this.editorView.state.doc.toString();
+        const data = JSON.parse(json);
+        
+        this.fileService.setACL(this.aclFilePath, data, result => {
+          if (result.status === Result.OK) {
+            MessageDialog.create("title.acl_editor_success", "message.edit_acl_success")
+              .setClassName("info")
+              .setI18N(this.application.i18n).show();
+            this.hide();
+          } else {
+            MessageDialog.create("title.acl_editor_error", "message.edit_acl_denied", result.message)
+              .setClassName("error")
+              .setI18N(this.application.i18n).show();
+          }
+        });
+      } catch (error) {
+        MessageDialog.create("Error", "message.edit_acl_error", error.message)
+          .setClassName("error")
+          .setI18N(this.application.i18n).show();
+      }
+    });
+  }
+
+
+  setACL(data)
+  {
+    const json = JSON.stringify(data, null, 2);
+    this.editorView.dispatch({
+      changes: { from: 0, to: this.editorView.state.doc.length, insert: json }
+    });
+  }
+
+  load()
+  {
+    this.fileService.getACL(this.aclFilePath, result =>
+    {
+      this.show();
+    });
+  }
+}
+
+export { ACLEditorDialog };

--- a/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
@@ -272,7 +272,7 @@ class FileExplorer extends Panel
   {
     const application = this.application;
     const aclFilePath = this.basePath;
-    const dialog = new ACLEditorDialog(application, this.service, aclFilePath);
+    const dialog = new ACLEditorDialog(application, this.service, aclFilePath, this);
     dialog.load();
   }
 

--- a/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
@@ -11,9 +11,10 @@ import { LoginDialog } from "./LoginDialog.js";
 import { ServiceDialog } from "./ServiceDialog.js";
 import { MessageDialog } from "./MessageDialog.js";
 import { ConfirmDialog } from "./ConfirmDialog.js";
+import { ACLEditorDialog } from "./ACLEditorDialog.js";
 import { Toast } from "./Toast.js";
 import { ServiceManager } from "../io/ServiceManager.js";
-import { FileService, Metadata, Result } from "../io/FileService.js";
+import { FileService, Metadata, Result, ACL } from "../io/FileService.js";
 import { IOManager } from "../io/IOManager.js";
 import { I18N } from "../i18n/I18N.js";
 
@@ -97,6 +98,7 @@ class FileExplorer extends Panel
 
     this.addCommonContextButtons();
     this.addServiceContextButtons();
+    this.addAclContextButton();
   }
 
   addCommonContextButtons()
@@ -116,6 +118,13 @@ class FileExplorer extends Panel
     this.addContextButton("download", "button.download",
       () => this.download(this.basePath + "/" + this.entryName),
       () => this.isDirectoryList() && this.isFileEntrySelected());
+  }
+
+  addAclContextButton()
+  {
+    this.addContextButton("acl", "button.edit_acl",
+      () => this.showAclDialog(),
+      () => this.isDirectoryList());
   }
 
   addServiceContextButtons()
@@ -257,6 +266,14 @@ class FileExplorer extends Panel
     inputFile.addEventListener("change",
       event => this.upload(inputFile.files));
     inputFile.click();
+  }
+
+  showAclDialog()
+  {
+    const application = this.application;
+    const aclFilePath = this.basePath;
+    const dialog = new ACLEditorDialog(application, this.service, aclFilePath);
+    dialog.load();
   }
 
   openPath(path, onSuccess)


### PR DESCRIPTION
- WebDAV Interface: Added ACL (modify) and PROPFIND methods for ACL Query.
- WebDAV service (front-end): Methods have been added to interact from the front-end with the new ACL modification method.
- Permissions Dialog (front-end): dialog to edit permissions, overwriting the current permissions with those entered by the user.
- ON-GOING: Get ACLs from the front-end webdavservice and display current permissions in the Permissions Dialog.
- Update:
-- The Merge Request has been updated to comply with community standards and formats.
-- Removed gson from pom
-- Moved webdavservlet to webdav, use ioutils for reader
-- Renamed ACLXML classes, returns ACL doACL